### PR TITLE
Name fix and working network example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Run iVentoy with the volume for data mounted.
 docker run -d --privileged -p 69:69 -p 26000:26000 -p 16000:16000 -p 10809:10809 -v /path/to/isos:/iventoy/iso -v /path/to/data:/iventoy/data --name iventoy garybowers/iventoy:latest
 ```
 
+Alternatively run on host mode to serve PXE to docker host's LAN:
+
+```
+docker run -d --privileged --net=host -v /path/to/isos:/iventoy/iso -v /path/to/data:/iventoy/data --name iventoy garybowers/iventoy:latest
+```
+
 ### Configure your DHCP server
 See the [docs](docs/) folder for examples.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Another oddity with iVentoy it looks for a /iventoy/data/iventoy.dat file and if
 
 1. Run iVentoy without the data volume mapped 
 ```
-docker run -d --privileged -p 69:69 -p 26000:26000 -p 16000:16000 -p 10809:10809 -v /path/to/isos:/iventoy/iso garybowers/iventoy:latest --name iventoy-temp
+docker run -d --privileged -p 69:69 -p 26000:26000 -p 16000:16000 -p 10809:10809 -v /path/to/isos:/iventoy/iso --name iventoy-tmp garybowers/iventoy:latest
 ```
 
 copy the contents of the data folder to your persistent storage
@@ -70,7 +70,7 @@ docker rm iventoy-tmp --force
 Run iVentoy with the volume for data mounted.
 
 ```
-docker run -d --privileged -p 69:69 -p 26000:26000 -p 16000:16000 -p 10809:10809 -v /path/to/isos:/iventoy/iso garybowers/iventoy:latest --name iventoy-temp
+docker run -d --privileged -p 69:69 -p 26000:26000 -p 16000:16000 -p 10809:10809 -v /path/to/isos:/iventoy/iso -v /path/to/data:/iventoy/data --name iventoy garybowers/iventoy:latest
 ```
 
 ### Configure your DHCP server


### PR DESCRIPTION
I suppose the snippet for following has a typo, as it has the temporary container's line verbatim.
```
Run iVentoy with the volume for data mounted.
```

So putting what worked for me, using `--net=host`.

Apart from that, at least on Debian 12 repos, `docker.io` does not allow using `--name` tag after the image, that also has been fixed. And abbreviation of temporary fixed to `tmp` from `temp`.